### PR TITLE
Fix building with go <1.8

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -1195,7 +1195,7 @@ func (c *conn) exec(ctx context.Context, query string, args []namedValue) (r dri
 		}()
 	}
 
-	s, err := c.PrepareContext(ctx, query)
+	s, err := c.prepare(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1241,7 @@ func (c *conn) query(ctx context.Context, query string, args []namedValue) (r dr
 			tracer(c, "Query(%s, %v): (%v, %v)", query, args, r, err)
 		}()
 	}
-	s, err := c.PrepareContext(ctx, query)
+	s, err := c.prepare(ctx, query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tests still fail:
```
# github.com/cznic/sqlite
./all_test.go:233: undefined: sort.Slice
./all_test.go:272: undefined: sort.Slice
./all_test.go:323: undefined: sort.Slice
FAIL    github.com/cznic/sqlite [build failed]
```